### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/sql-migration-agents/requirements.txt
+++ b/sql-migration-agents/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 openai==1.3.5
-pyautogen>=0.2.0
+ag2>=0.2.0
 sqlparse==0.4.4
 pydantic==1.10.8
 

--- a/sql-migration-agents/setup.py
+++ b/sql-migration-agents/setup.py
@@ -11,7 +11,7 @@ setup(
     author="Data Modernization Team",
     packages=find_packages(),
     install_requires=[
-        "pyautogen>=0.2.0",
+        "ag2>=0.2.0",
         "loguru",
         "sqlparse",
         "python-dotenv",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
